### PR TITLE
fix: compatibility with pandas 3.0 and xarray 2026.4

### DIFF
--- a/docs/notebooks/bias_correction.ipynb
+++ b/docs/notebooks/bias_correction.ipynb
@@ -654,7 +654,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "db96cb85",
    "metadata": {},
    "outputs": [
@@ -669,7 +669,7 @@
    ],
    "source": [
     "%%time\n",
-    "ds_pws = ds_pws_orig.resample(time=\"1H\").sum(min_count=10)"
+    "ds_pws = ds_pws_orig.resample(time=\"1h\").sum(min_count=10)"
    ]
   },
   {

--- a/docs/notebooks/indicator_correlation_filter.ipynb
+++ b/docs/notebooks/indicator_correlation_filter.ipynb
@@ -656,12 +656,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "db96cb85",
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds_pws = ds_pws_orig.resample(time=\"1H\").sum(min_count=10)"
+    "ds_pws = ds_pws_orig.resample(time=\"1h\").sum(min_count=10)"
    ]
   },
   {

--- a/src/pypwsqc/peak_removal_filter.py
+++ b/src/pypwsqc/peak_removal_filter.py
@@ -3,6 +3,7 @@
 # import packages
 
 import numpy as np
+import pandas as pd
 import poligrain as plg
 import xarray as xr
 from poligrain.spatial import project_point_coordinates
@@ -237,8 +238,7 @@ def print_info(
     pws_neighbors = (
         np.count_nonzero(
             [
-                aa_closest_neighbors.sel(id=station).neighbor_id.to_numpy()[i]
-                is not None
+                pd.notna(aa_closest_neighbors.sel(id=station).neighbor_id.to_numpy()[i])
                 for i in range(
                     len(aa_closest_neighbors.sel(id=station).neighbor_id.to_numpy())
                 )
@@ -268,8 +268,7 @@ def print_info(
     else:
         ref_neighbors = np.count_nonzero(
             [
-                ab_closest_neighbors.sel(id=station).neighbor_id.to_numpy()[i]
-                is not None
+                pd.notna(ab_closest_neighbors.sel(id=station).neighbor_id.to_numpy()[i])
                 for i in range(
                     len(aa_closest_neighbors.sel(id=station).neighbor_id.to_numpy())
                 )
@@ -386,7 +385,7 @@ def interpolate_precipitation(
         neighbors = closest_neighbors.sel(id=station).neighbor_id.to_numpy()
         weights = weights_da.sel(id=station).to_numpy()
 
-    if np.all([value is None for value in neighbors]):
+    if np.all([pd.isna(value) for value in neighbors]):
         print(f"No neighbors found for station {station}.")
         return []
 
@@ -398,14 +397,12 @@ def interpolate_precipitation(
         neighbors,
         desc="Get precipitation values from neighbors",
         unit=" neighbors",
-        total=np.count_nonzero(
-            [neighbors[i] is not None for i in range(len(neighbors))]
-        ),
+        total=np.count_nonzero([pd.notna(neighbors[i]) for i in range(len(neighbors))]),
     ):
         neighbor_seqs = []
         # list of time series of the neighbor containing his time series with starts
         # and ends of nan sequences of the selected station
-        if neighbor is None:  # stop if there are no (no more) neighbors
+        if pd.isna(neighbor):  # stop if there are no (no more) neighbors
             break
         # iterate over all nan sequences of the selected station
         for seq_start, peak, seq_len in zip(

--- a/src/pypwsqc/peak_removal_filter_plots.py
+++ b/src/pypwsqc/peak_removal_filter_plots.py
@@ -4,6 +4,7 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import xarray as xr
 from matplotlib.lines import Line2D
 from matplotlib.patches import Circle
@@ -71,7 +72,7 @@ def plot_station_neighbors(
         plt.scatter(x=x_ref, y=y_ref, s=s, color="black", alpha=0.5)
 
     for neighbor in aa_neighbor:
-        if neighbor is None:
+        if pd.isna(neighbor):
             continue
         plt.scatter(
             a_dataset.sel(id=neighbor).x.to_numpy(),
@@ -82,7 +83,7 @@ def plot_station_neighbors(
         )
     if b_dataset is not None:
         for neighbor_ref in ab_neigbors:
-            if neighbor_ref is None:
+            if pd.isna(neighbor_ref):
                 continue
             plt.scatter(
                 b_dataset.sel(id=neighbor_ref).x.to_numpy(),


### PR DESCRIPTION
Two compatibility fixes for breaking changes introduced in pandas 3.0 / xarray 2026.4.

### `None` → `NaN` in xarray object arrays (fixes test failures on Python 3.11/3.12)

xarray 2026.4 / pandas 3.0 changed how `None` sentinels in object-dtype arrays are
handled: `.to_numpy()` now returns `float NaN` instead of `None`. The
`neighbor_id` variable in the closest-neighbors datasets used `None` to mark
missing neighbors. All identity checks against `None` on values from
`.to_numpy()` arrays are replaced with `pd.isna()` / `pd.notna()`, which handle
both `None` and `NaN` correctly.

Affected functions: `print_info`, `interpolate_precipitation`
(`peak_removal_filter.py`), `plot_station_neighbors`
(`peak_removal_filter_plots.py`).

### Deprecated uppercase frequency alias `'1H'` (fixes CI notebook failures)

Uppercase pandas frequency aliases (`H`, `T`, `S`, …) were deprecated in pandas
2.2 and removed in pandas 3.0. Replace `resample(time="1H")` with
`resample(time="1h")` in `bias_correction.ipynb` and
`indicator_correlation_filter.ipynb`.